### PR TITLE
Change maintainer username from @astrofrog-conda-forge to @astrofrog

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -15,11 +15,6 @@ jobs:
   timeoutInMinutes: 360
 
   steps:
-  - script: |
-         rm -rf /opt/ghc
-         df -h
-    displayName: Manage disk space
-
   # configure qemu binfmt-misc running.  This allows us to run docker containers
   # embedded qemu-static
   - script: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 # This file was generated automatically from conda-smithy. To update this configuration,
 # update the conda-forge.yml and/or the recipe/meta.yaml.
-# -*- mode: yaml -*-
+# -*- mode: jinja-yaml -*-
 
 version: 2
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @astrofrog-conda-forge @dopplershift
+* @astrofrog @dopplershift

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-About pytest-mpl
-================
+About pytest-mpl-feedstock
+==========================
+
+Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/pytest-mpl-feedstock/blob/main/LICENSE.txt)
 
 Home: https://github.com/matplotlib/pytest-mpl
 
 Package license: BSD-2-Clause
-
-Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/pytest-mpl-feedstock/blob/main/LICENSE.txt)
 
 Summary: pytest plugin to help with testing figures output from Matplotlib
 
@@ -145,6 +145,6 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
-* [@astrofrog-conda-forge](https://github.com/astrofrog-conda-forge/)
+* [@astrofrog](https://github.com/astrofrog/)
 * [@dopplershift](https://github.com/dopplershift/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,4 +48,4 @@ about:
 extra:
   recipe-maintainers:
     - dopplershift
-    - astrofrog-conda-forge
+    - astrofrog


### PR DESCRIPTION
This is to update my username from @astrofrog-conda-forge to @astrofrog - I used to have a separate username back when being a member of any conda-forge repository meant that I saw all conda-forge repositories on Travis CI but this is no longer relevant.

@conda-forge-admin please rerender